### PR TITLE
Updated nokogiri to 1.6.0

### DIFF
--- a/odf-report.gemspec
+++ b/odf-report.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency('rubyzip', "~> 0.9.4")
-  s.add_runtime_dependency('nokogiri', "~> 1.5.0")
+  s.add_runtime_dependency('nokogiri', "~> 1.6.0")
 
 end


### PR DESCRIPTION
Testing reveals no further changes were needed other than to update the gemspec.

Signed-off-by: Nathan Lowrie nate@finelineautomation.com
