### PR TITLE
Add support for touching up the XML with Nokogiri

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -215,6 +215,35 @@ end
 report.generate("./documents/new_ticket.odt")
 </pre>
 
+h4. Manual touchups to the generated XML
+
+There may be cases where odf-report gets you to within spitting distance
+of how you want the XML to look. For example, you may want to apply
+conditional formatting, by changing the style of paragraphs that meet some
+criterion. ODFReport doesn't come with support for this out of the box, but
+you can override the @touchup@ hook, like so:
+
+<pre>
+module ODFReport
+  class Report
+    def touchup(doc)
+      doc.xpath("//text:p/text()").each do |p|
+        if p.text =~ /\[STYLE=(.+?)\]/
+          match=$1
+          text = p.text.to_s.sub(/\[STYLE=(.+?)\]/, '')
+          p.content = text
+          p.parent.attributes['style-name'].value=match
+        end
+      end
+    end
+  end
+end
+</pre>
+
+The @touchup@ hook has access to the entire Nokogiri document. The
+example changes the paragraph style of any paragraph having a
+[STYLE=_name_] tag to the given style name, and removes the tag.
+
 <hr/>
 
 h3. REQUIREMENTS

--- a/lib/odf-report/report.rb
+++ b/lib/odf-report/report.rb
@@ -50,6 +50,10 @@ class Report
     @images[name] = path
   end
 
+  # Override this routine if you need to tweak the generated XML
+  def touchup(doc)
+  end
+
   def generate(dest = nil)
 
     @file.update_content do |file|
@@ -66,6 +70,8 @@ class Report
 
           find_image_name_matches(doc)
           avoid_duplicate_image_names(doc)
+
+          touchup(doc)
 
         end
 

--- a/spec/touchup_spec.rb
+++ b/spec/touchup_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe "Touchup" do
+
+  before(:context) do
+
+    module ODFReport
+      class Report
+        alias_method :old_touchup, :touchup
+        def touchup(doc)
+          doc.xpath("//text:p/text()").each do |p|
+            if p.text =~ /\[STYLE=(.+?)\]/
+              match=$1
+              text = p.text.to_s.sub(/\[STYLE=(.+?)\]/, '')
+              p.content = text
+              p.parent.attributes['style-name'].value=match
+            end
+          end
+        end
+      end
+    end
+
+    report = ODFReport::Report.new("spec/specs.odt") do |r|
+
+      r.add_field(:field_01, "[STYLE=teststyle]Testing!")
+    end
+
+    report.generate("spec/result/specs.odt")
+
+    @data = Inspector.new("spec/result/specs.odt")
+
+  end
+
+
+  it "should change the style of the paragraph" do
+
+    expect(@data.text).not_to match(/\[STYLE=/)
+    expect(@data.text).to match(/Testing!/)
+
+    # The XML will look like this:
+    # <text:p text:style-name="teststyle">Field_01: Testing!</text:p>
+    expect(@data.xml.xpath("//text:p[@text:style-name='teststyle']/text()").first).to match(/Testing!/)
+
+  end
+
+end


### PR DESCRIPTION
I often find myself postprocessing the generated .odt file. This pull requests adds a method that can be overridden (or replaced outright), to get a handle on the Nokogiri XML tree before it gets saved to disk.

Includes a README blurb and tests.

A lot of important magic happens in the generate method, so the processing needs to take place there. But I'll be happy to rework this if an alternate approach (e.g., passing an optional function reference to generate or whatever) is deemed a better solution.