### PR TITLE
Fix Google Docs odt by ignoring superfluous tags

### DIFF
--- a/lib/odf-report/field.rb
+++ b/lib/odf-report/field.rb
@@ -1,8 +1,6 @@
 module ODFReport
   class Field
 
-    DELIMITERS = %w([ ])
-
     def initialize(opts, &block)
       @name = opts[:name]
       @data_field = opts[:data_field]
@@ -57,11 +55,8 @@ module ODFReport
     private
 
     def to_placeholder
-      if DELIMITERS.is_a?(Array)
-        "#{DELIMITERS[0]}#{@name.to_s.upcase}#{DELIMITERS[1]}"
-      else
-        "#{DELIMITERS}#{@name.to_s.upcase}#{DELIMITERS}"
-      end
+      # this regexp is used to ignore superfluous tags like </text:span><text:span>
+      %r{\[(</[^><]*><[^/><]*>)?#{@name.to_s.upcase}(</[^><]*><[^/><]*>)?\]}
     end
 
     def sanitize(txt)


### PR DESCRIPTION
This commit adds a regular expressions that makes sure the replacement tags are still recognized in odt files created by Google Docs. For example, it works with:

```
<text:span>[</text:span><text:span>SOMETHING</text:span><text:span>]</text:span>
```
