### PR TITLE
Avoid exceptions when odt does not contain images

### DIFF
--- a/lib/odf-report/images.rb
+++ b/lib/odf-report/images.rb
@@ -31,12 +31,15 @@ module ODFReport
     # newer versions of LibreOffice can't open files with duplicates image names
     def avoid_duplicate_image_names(content)
 
-      nodes = content.xpath("//draw:frame[@draw:name]")
+      begin
+        nodes = content.xpath("//draw:frame[@draw:name]")
 
-      nodes.each_with_index do |node, i|
-        node.attribute('name').value = "pic_#{i}"
+        nodes.each_with_index do |node, i|
+          node.attribute('name').value = "pic_#{i}"
+        end
+      rescue => e
+        raise unless e.message.include? 'Unknown namespace'
       end
-
     end
 
   end


### PR DESCRIPTION
This error occurs for me in documents without images. I think it is save to ignore.
