### PR TITLE
ODF Consecutive space support to propery insert consecutive spaces

### DIFF
--- a/lib/odf-report/field.rb
+++ b/lib/odf-report/field.rb
@@ -67,6 +67,7 @@ module ODFReport
     def sanitize(txt)
       txt = html_escape(txt)
       txt = odf_linebreak(txt)
+      txt = odf_consecutive_spaces(txt)
       txt
     end
 
@@ -76,7 +77,12 @@ module ODFReport
       return "" unless s
       s.to_s.gsub(/[&"><]/) { |special| HTML_ESCAPE[special] }
     end
-
+    
+    def odf_consecutive_spaces(s)
+    return "" unless s
+    s..gsub(/ {2,}/){|r| "<text:s text:c=\"#{r.count(" ").to_s }\"/>"}
+    end
+    
     def odf_linebreak(s)
       return "" unless s
       s.to_s.gsub("\n", "<text:line-break/>")

--- a/lib/odf-report/field.rb
+++ b/lib/odf-report/field.rb
@@ -80,7 +80,7 @@ module ODFReport
     
     def odf_consecutive_spaces(s)
     return "" unless s
-    s..gsub(/ {2,}/){|r| "<text:s text:c=\"#{r.count(" ").to_s }\"/>"}
+    s.gsub(/ {2,}/){|r| "<text:s text:c=\"#{r.count(" ").to_s }\"/>"}
     end
     
     def odf_linebreak(s)

--- a/lib/odf-report/version.rb
+++ b/lib/odf-report/version.rb
@@ -1,3 +1,3 @@
 module ODFReport
-  VERSION = "0.5.1"
+  VERSION = "0.5.2"
 end

--- a/lib/odf-report/version.rb
+++ b/lib/odf-report/version.rb
@@ -1,3 +1,0 @@
-module ODFReport
-  VERSION = "0.5.2"
-end


### PR DESCRIPTION
This converts strings of greater than one space character into ODF consecutive space tags and attempts to address bug #31 . It passes a rudimentary test but I'd be happy to hear if there are there are situations where it breaks.
