### PR TITLE
Add support for user defined metadata extraction from template file

### DIFF
--- a/lib/odf-report/file.rb
+++ b/lib/odf-report/file.rb
@@ -46,5 +46,11 @@ module ODFReport
       @buffer.string
     end
 
+    def meta
+      Zip::File.open(@template) do |file|
+        file.read('meta.xml')
+      end
+    end
+
   end
 end

--- a/lib/odf-report/report.rb
+++ b/lib/odf-report/report.rb
@@ -50,6 +50,10 @@ class Report
     @images[name] = path
   end
 
+  def user_metadata
+    @file_meta ||= file_user_meta
+  end
+
   def generate(dest = nil)
 
     @file.update_content do |file|
@@ -89,6 +93,16 @@ private
     doc = Nokogiri::XML(txt)
     yield doc
     txt.replace(doc.to_xml(:save_with => Nokogiri::XML::Node::SaveOptions::AS_XML))
+  end
+
+  def file_user_meta
+    meta_data = {}
+
+    Nokogiri::XML(@file.meta).xpath('//meta:user-defined').each do |node|
+      meta_data[node.values.first] = node.child.content
+    end
+
+    meta_data
   end
 
 end

--- a/lib/odf-report/version.rb
+++ b/lib/odf-report/version.rb
@@ -1,3 +1,3 @@
 module ODFReport
-  VERSION = "0.5.1"
+  VERSION = "0.5.2"
 end


### PR DESCRIPTION
Hello!

I needed to change behaviour of one particular field/table from template to template (user can change template in our system) and ended up create a custom property (user defined metedata, can be found in File / Properties / Custom Properties) in template file.

For example, there is a table `:route_table`, which can hold 30 rows by default of data maximum, but some of users want a smaller template, only for 15 rows (some other users 20 rows, etc). So, user can create custom property named 'route_table_max' and set it to needed value. System can load it before report generation and change default maximum to custom defined.

Usage:
``` ruby
ODFReport::Report.new('template.odt') do |report|
  # load user defined metadata as hash
  meta = report.user_metadata
  
  # use new variable or default
  max_rows = validate(meta['route_table_max'], 30)
  
  table_data = generate(max_rows, raw_data)

  report.add_table(:route_table, table_data, header:false) do |t|
    ...
  end

  report.generate(output_file)
end
```