### PR TITLE
Add a Table option: required

### DIFF
--- a/lib/odf-report/table.rb
+++ b/lib/odf-report/table.rb
@@ -15,6 +15,7 @@ class Table
     @template_rows = []
     @header           = opts[:header] || false
     @skip_if_empty    = opts[:skip_if_empty] || false
+    @required         = opts[:required] || false
   end
 
   def replace!(doc, row = nil)
@@ -79,7 +80,15 @@ private
 
     tables = doc.xpath(".//table:table[@table:name='#{@name}']")
 
-    tables.empty? ? nil : tables.first
+    if tables.empty?
+      if @required
+        raise format('Required table not found: %s', @name)
+      else
+        nil
+      end
+    else
+      tables.first
+    end
 
   end
 

--- a/spec/tables_spec.rb
+++ b/spec/tables_spec.rb
@@ -36,4 +36,22 @@ RSpec.describe "Tables" do
 
   end
 
+  context "when required table is not found" do
+
+    it "raises error" do
+      table_name = 'nonexistent'
+      table = ::ODFReport::Table.new(
+        collection: [],
+        name: table_name,
+        required: true
+      )
+      doc = double('document')
+      allow(doc).to receive(:xpath).and_return([])
+      expect {
+        table.send(:find_table_node, doc)
+      }.to raise_error(format('Required table not found: %s', table_name))
+    end
+
+  end
+
 end


### PR DESCRIPTION
At my co. we allow non-developers to edit report templates.
They often will (somehow) change the name of a table in the
template. Raising an error for important table would help
us identify this mistake more quickly.