### PR TITLE
proposed change for issue #117

### DIFF
--- a/lib/odf-report/field.rb
+++ b/lib/odf-report/field.rb
@@ -17,9 +17,12 @@ module ODFReport
 
       txt = content.inner_html
 
-      txt.gsub!(to_placeholder, sanitize(@data_source.value))
+      replaced = txt.gsub!(to_placeholder, sanitize(@data_source.value))
 
-      content.inner_html = txt
+      # replacing inner_html is memory expensive, only do it if a change was made
+      if replaced 
+        content.inner_html = txt
+      end
 
     end
 


### PR DESCRIPTION
Only call `inner_html=` if content has changed to miitigate unnecessary memory usage. 