### PR TITLE
Add configurable placeholder delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,35 @@ There are five kinds of substitutions available:
 - **Sections** — repeat entire document sections with nested content
 - **Images** — swap placeholder images with actual image files
 
+## Configurable delimiters
+
+By default, placeholders are wrapped in square brackets (`[NAME]`). You can switch
+to double curly braces or supply your own pair:
+
+```ruby
+ODFReport.delimiters = :square       # [NAME]   (default)
+ODFReport.delimiters = :curly        # {{NAME}}
+ODFReport.delimiters = ["((", "))"]  # ((NAME))
+```
+
+Set it once (for example, in an initializer). To scope a choice to a single report,
+use the block form, which restores the previous value afterwards:
+
+```ruby
+ODFReport.with_delimiters(:curly) do
+  ODFReport::Report.new("template.odt") { |r| r.add_field(:name, "Acme") }.generate("out.odt")
+end
+```
+
+Notes:
+
+- Placeholder names are still upper-cased, so under `:curly` the template token for
+  `add_field(:name)` is `{{NAME}}`, not `{{name}}`.
+- Delimiters must not contain the XML characters `<`, `>`, or `&` — they are escaped
+  inside the document and would never match, so such values raise an `ArgumentError`.
+- The setting is process-global and not thread-safe for concurrently rendering reports
+  that need *different* delimiters; choose one consistent value in that case.
+
 ## Documentation
 
 - [Installation](https://sandrods.github.io/odf-report/docs/installation) — setup and requirements

--- a/lib/odf-report.rb
+++ b/lib/odf-report.rb
@@ -7,6 +7,8 @@ require "securerandom"
 
 require File.expand_path("../odf-report/parser/default", __FILE__)
 
+require File.expand_path("../odf-report/configuration", __FILE__)
+
 require File.expand_path("../odf-report/data_source", __FILE__)
 require File.expand_path("../odf-report/field", __FILE__)
 require File.expand_path("../odf-report/text", __FILE__)

--- a/lib/odf-report/configuration.rb
+++ b/lib/odf-report/configuration.rb
@@ -1,0 +1,73 @@
+module ODFReport
+
+  # Configurable placeholder delimiters.
+  #
+  # By default field names are wrapped in square brackets ([NAME]). You can
+  # switch to double curly braces, or supply your own pair:
+  #
+  #   ODFReport.delimiters = :square       # [NAME]   (default)
+  #   ODFReport.delimiters = :curly        # {{NAME}}
+  #   ODFReport.delimiters = ["((", "))"]  # ((NAME))
+  #
+  # Or scope a choice to a single block, restoring the previous value after:
+  #
+  #   ODFReport.with_delimiters(:curly) do
+  #     ODFReport::Report.new("template.odt") { |r| r.add_field(:name, "Acme") }.generate("out.odt")
+  #   end
+  #
+  # Note: placeholder names are still upper-cased, so with :curly the template
+  # token for add_field(:name) is {{NAME}}, not {{name}}.
+  module Configuration
+
+    SQUARE = ["[", "]"].freeze
+    CURLY  = ["{{", "}}"].freeze
+
+    PRESETS = { square: SQUARE, curly: CURLY }.freeze
+
+    def delimiters
+      @delimiters ||= SQUARE.dup
+    end
+
+    def delimiters=(value)
+      @delimiters = coerce_delimiters(value)
+    end
+
+    # Temporarily use a delimiter set for the duration of the block, then
+    # restore the previous value (handy in tests and for one-off reports).
+    # Note: this mutates process-global state and is not thread-safe; for
+    # concurrent reports needing different delimiters, set one consistent value.
+    def with_delimiters(value)
+      previous = @delimiters
+      self.delimiters = value
+      yield
+    ensure
+      @delimiters = previous
+    end
+
+    private
+
+    def coerce_delimiters(value)
+      case value
+      when Symbol, String
+        PRESETS[value.to_sym] ||
+          raise(ArgumentError, "Unknown delimiter preset #{value.inspect}; " \
+                               "use :square, :curly, or a two-element array of strings")
+      when Array
+        unless value.size == 2 && value.all? { |v| v.is_a?(String) && !v.empty? }
+          raise ArgumentError, "delimiters must be a two-element array of non-empty strings, got #{value.inspect}"
+        end
+        if value.any? { |v| v.match?(/[<>&]/) }
+          raise ArgumentError, "delimiters must not contain XML metacharacters (< > &); " \
+                               "they are escaped in the document and would never match"
+        end
+        value.map(&:dup).freeze
+      else
+        raise ArgumentError, "delimiters must be a Symbol preset or a two-element array, got #{value.class}"
+      end
+    end
+
+  end
+
+  extend Configuration
+
+end

--- a/lib/odf-report/field.rb
+++ b/lib/odf-report/field.rb
@@ -1,6 +1,5 @@
 module ODFReport
   class Field
-    DELIMITERS = %w([ ])
 
     def initialize(opts, &block)
       @name = opts[:name]
@@ -23,7 +22,8 @@ module ODFReport
     private
 
     def to_placeholder
-      "#{DELIMITERS[0]}#{@name.to_s.upcase}#{DELIMITERS[1]}"
+      open, close = ODFReport.delimiters
+      "#{open}#{@name.to_s.upcase}#{close}"
     end
 
     def sanitize(txt)

--- a/test/configurable_delimiters_test.rb
+++ b/test/configurable_delimiters_test.rb
@@ -1,0 +1,77 @@
+require "./lib/odf-report"
+require "tmpdir"
+
+NS = %(xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" ) +
+     %(xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0")
+
+def content_xml(body)
+  %(<?xml version="1.0"?><office:document-content #{NS}>) +
+    %(<office:body><office:text>#{body}</office:text></office:body></office:document-content>)
+end
+
+def build_template(dir, body)
+  path = File.join(dir, "tpl.odt")
+  Zip::OutputStream.open(path) do |z|
+    z.put_next_entry("mimetype"); z.write("application/vnd.oasis.opendocument.text")
+    z.put_next_entry("content.xml"); z.write(content_xml(body))
+    z.put_next_entry("META-INF/manifest.xml")
+    z.write(%(<?xml version="1.0"?><manifest:manifest ) +
+            %(xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0">) +
+            %(<manifest:file-entry manifest:full-path="/" ) +
+            %(manifest:media-type="application/vnd.oasis.opendocument.text"/></manifest:manifest>))
+  end
+  path
+end
+
+def render(template_body, &block)
+  Dir.mktmpdir do |dir|
+    src = build_template(dir, template_body)
+    out = File.join(dir, "out.odt")
+    ODFReport::Report.new(src, &block).generate(out)
+    Zip::File.open(out) { |z| return z.read("content.xml") }
+  end
+end
+
+failures = 0
+check = lambda do |cond, msg|
+  puts(cond ? "PASS: #{msg}" : "FAIL: #{msg}")
+  failures += 1 unless cond
+end
+
+# default is square brackets
+check.(ODFReport.delimiters == ["[", "]"], "default delimiters are square brackets")
+out = render("<text:p>[NAME]</text:p>") { |r| r.add_field(:name, "Acme") }
+check.(out.include?("Acme") && !out.include?("[NAME]"), "[NAME] replaced by default")
+
+# curly preset, end to end
+ODFReport.delimiters = :curly
+check.(ODFReport.delimiters == ["{{", "}}"], ":curly preset sets {{ }}")
+out = render("<text:p>{{NAME}}</text:p>") { |r| r.add_field(:name, "Acme") }
+check.(out.include?("Acme") && !out.include?("{{NAME}}"), "{{NAME}} replaced when :curly")
+# square no longer matches while curly active
+out = render("<text:p>[NAME]</text:p>") { |r| r.add_field(:name, "Acme") }
+check.(out.include?("[NAME]"), "[NAME] left intact while curly active")
+ODFReport.delimiters = :square # reset
+
+# custom pair (must be XML-safe)
+ODFReport.delimiters = ["((", "))"]
+out = render("<text:p>((NAME))</text:p>") { |r| r.add_field(:name, "Acme") }
+check.(out.include?("Acme"), "custom ((NAME)) pair works")
+ODFReport.delimiters = :square
+
+# block scoping restores previous value
+ODFReport.with_delimiters(:curly) do
+  check.(ODFReport.delimiters == ["{{", "}}"], "with_delimiters switches inside block")
+end
+check.(ODFReport.delimiters == ["[", "]"], "with_delimiters restores after block")
+
+# validation
+bad = 0
+[:nope, "x", ["only-one"], 42, ["a", ""], ["<<", ">>"]].each do |v|
+  begin; ODFReport.delimiters = v; rescue ArgumentError; bad += 1; end
+end
+check.(bad == 6, "invalid delimiter values (incl. XML-unsafe) raise ArgumentError")
+ODFReport.delimiters = :square
+
+abort("\n#{failures} failure(s)") unless failures.zero?
+puts "\nOK (#{failures} failures)"


### PR DESCRIPTION
Lets users choose the delimiter style used to wrap field names in templates, instead of being locked to [NAME].

**Why**

The [ ] delimiter is hardcoded, which clashes with templates that legitimately contain square brackets and rules out the {{ }} style many users expect from other templating tools. This makes the delimiter a configuration choice while keeping the default unchanged.

**What**

- New ODFReport.delimiters= setting accepting a preset (:square, :curly) or a custom two-element pair, e.g. ["((", "))"]. Default stays :square, so existing templates are unaffected.
- ODFReport.with_delimiters(value) { ... } block helper to scope a choice to a single render and restore the previous value afterward.
- Validation rejects malformed pairs and any delimiter containing the XML metacharacters < > &, since those are escaped in the document and would silently never match.
- All placeholder types (fields, texts, images) pick this up automatically, since they resolve through Field#to_placeholder.

**Notes**

- Placeholder names are still upper-cased, so under :curly the token for add_field(:name) is {{NAME}}.
- The setting is process-global; documented as not thread-safe for concurrently rendering reports that need different delimiters.

**Tests / docs**

- Added test/configurable_delimiters_test.rb covering the default, each preset, a custom pair, block scoping with restore, and the validation cases.
- Added a "Configurable delimiters" section to the README.