### PR TITLE
Add support for HTML lists, improve handling of HTML special entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ report.generate("output.odt")
 There are five kinds of substitutions available:
 
 - **Fields** — replace `[PLACEHOLDER]` text with values
-- **Texts** — replace placeholders with HTML-formatted content
+- **Texts** — replace placeholders with HTML-formatted content (paragraphs, headings, inline `strong`/`em`/`u`, and `ul`/`ol` lists, including nested lists)
 - **Tables** — repeat table rows for each item in a collection
 - **Sections** — repeat entire document sections with nested content
 - **Images** — swap placeholder images with actual image files

--- a/lib/odf-report/parser/default.rb
+++ b/lib/odf-report/parser/default.rb
@@ -2,24 +2,31 @@ module ODFReport
   module Parser
     # Default HTML parser
     #
-    # sample HTML
+    # Converts an HTML fragment into ODF nodes. Supported:
+    #   - <p>, <h1>..<h6>                -> paragraphs (headings use "title")
+    #   - <blockquote>                   -> paragraphs use the "quote" style
+    #   - <ul>, <ol>, <li>               -> ODF lists (text:list / text:list-item),
+    #                                       including nested lists
+    #   - <strong>/<b>, <em>/<i>, <u>    -> styled text:span
+    #   - <br>                           -> text:line-break
     #
-    # <p> first paragraph </p>
-    # <p> second <strong>paragraph</strong> </p>
-    # <blockquote>
-    #     <p> first <em>quote paragraph</em> </p>
-    #     <p> first quote paragraph </p>
-    #     <p> first quote paragraph </p>
-    # </blockquote>
-    # <p> third <strong>paragraph</strong> </p>
+    # Any other element is unwrapped: its tags are dropped and its text kept.
+    # This guarantees only ODF elements end up in content.xml — foreign HTML
+    # tags (e.g. <a>, <span>, <div>) embedded verbatim would otherwise make
+    # LibreOffice reject the document with a "Format error".
     #
-    # <p style="margin: 100px"> fourth <em>paragraph</em> </p>
-    # <p style="margin: 120px"> fifth paragraph </p>
-    # <p> sixth <strong>paragraph</strong> </p>
-    #
-
     class Default
       attr_reader :paragraphs
+
+      LIST_TAGS = %w[ul ol].freeze
+
+      STYLE_TAGS = {
+        "strong" => "bold",  "b" => "bold",
+        "em"     => "italic", "i" => "italic",
+        "u"      => "underline", "ins" => "underline"
+      }.freeze
+
+      XML_ESCAPE = { "&" => "&amp;", "<" => "&lt;", ">" => "&gt;" }.freeze
 
       def initialize(text, template_node)
         @text = text
@@ -33,12 +40,26 @@ module ODFReport
 
       def parse
         html = Nokogiri::HTML5.fragment(@text)
+        process(html.children)
+      end
 
-        html.css("p", "h1", "h2").each do |p|
-          style = check_style(p)
-          text = parse_formatting(p.inner_html)
-
-          add_paragraph(text, style)
+      # Walk top-level nodes in document order so lists interleave correctly
+      # with paragraphs. Unknown container elements (e.g. <div>) are descended
+      # into, preserving the behaviour where nested paragraphs were picked up.
+      def process(nodes)
+        nodes.each do |node|
+          case node.name
+          when "p"
+            add_paragraph(inline_content(node), check_style(node))
+          when "h1", "h2", "h3", "h4", "h5", "h6"
+            add_paragraph(inline_content(node), "title")
+          when "ul", "ol"
+            @paragraphs << build_list(node)
+          when "text"
+            add_paragraph(escape(node.content), nil) unless node.text.strip.empty?
+          else
+            process(node.children) if node.element?
+          end
         end
       end
 
@@ -51,19 +72,58 @@ module ODFReport
         @paragraphs << node
       end
 
-      def parse_formatting(text)
-        text.strip!
-        text.gsub!(/<strong.*?>(.+?)<\/strong>/) { "<text:span text:style-name=\"bold\">#{$1}</text:span>" }
-        text.gsub!(/<em.*?>(.+?)<\/em>/) { "<text:span text:style-name=\"italic\">#{$1}</text:span>" }
-        text.gsub!(/<u.*?>(.+?)<\/u>/) { "<text:span text:style-name=\"underline\">#{$1}</text:span>" }
-        text.gsub!(/<br\/?>/, "<text:line-break/>")
-        text.delete!("\n")
-        text
+      # Build an ODF list as an in-context XML string (text: prefixes resolve
+      # against the document namespaces when inserted before the placeholder).
+      def build_list(node)
+        items = node.children.select { |c| c.name == "li" }.map { |li| build_list_item(li) }.join
+        %(<text:list>#{items}</text:list>)
+      end
+
+      def build_list_item(li)
+        inner  = ""
+        nested = []
+
+        li.children.each do |child|
+          if LIST_TAGS.include?(child.name)
+            nested << child
+          else
+            inner << inline_node(child)
+          end
+        end
+
+        body = %(<text:p>#{inner}</text:p>) + nested.map { |n| build_list(n) }.join
+        %(<text:list-item>#{body}</text:list-item>)
+      end
+
+      # Convert the inline children of an element into an ODF inline XML string.
+      def inline_content(node)
+        node.children.map { |child| inline_node(child) }.join
+      end
+
+      def inline_node(node)
+        if node.text?
+          escape(node.content)
+        elsif node.name == "br"
+          "<text:line-break/>"
+        elsif (style = STYLE_TAGS[node.name])
+          %(<text:span text:style-name="#{style}">#{inline_content(node)}</text:span>)
+        elsif node.element?
+          inline_content(node) # unwrap unknown/foreign tags, keep their text
+        else
+          "" # comments, processing instructions, etc.
+        end
+      end
+
+      # Decoded text -> well-formed, ODF-safe XML text. HTML entities have
+      # already been decoded to real characters by the HTML5 parser; we only
+      # need to escape the XML metacharacters and drop stray newlines.
+      def escape(text)
+        text.delete("\n").gsub(/[&<>]/, XML_ESCAPE)
       end
 
       def check_style(node)
-        return "title" if /h\d/i.match?(node.name)
         return "quote" if node.parent&.name == "blockquote"
+
         "quote" if /margin/.match?(node["style"])
       end
     end

--- a/test/html_inline_safety_test.rb
+++ b/test/html_inline_safety_test.rb
@@ -1,0 +1,70 @@
+require "./lib/odf-report"
+require "tmpdir"
+
+NS = %(xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" ) +
+     %(xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0")
+ODF_NS = "urn:oasis:names:tc:opendocument".freeze
+
+def render(html)
+  Dir.mktmpdir do |dir|
+    src = File.join(dir, "tpl.odt")
+    Zip::OutputStream.open(src) do |z|
+      z.put_next_entry("mimetype"); z.write("application/vnd.oasis.opendocument.text")
+      z.put_next_entry("content.xml")
+      z.write(%(<?xml version="1.0"?><office:document-content #{NS}>) +
+              %(<office:body><office:text><text:p>[BODY]</text:p></office:text></office:body></office:document-content>))
+      z.put_next_entry("META-INF/manifest.xml")
+      z.write(%(<?xml version="1.0"?><manifest:manifest ) +
+              %(xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0">) +
+              %(<manifest:file-entry manifest:full-path="/" ) +
+              %(manifest:media-type="application/vnd.oasis.opendocument.text"/></manifest:manifest>))
+    end
+    out = File.join(dir, "out.odt")
+    ODFReport::Report.new(src) { |r| r.add_text(:body, html) }.generate(out)
+    Zip::File.open(out) { |z| return z.read("content.xml") }
+  end
+end
+
+# Every element under office:text must live in an ODF namespace (no foreign
+# HTML tags), which is what LibreOffice's "Format error" rejects.
+def only_odf_elements?(xml)
+  doc = Nokogiri::XML(xml)
+  return false unless doc.errors.empty?
+  doc.xpath("//office:text//*").all? { |e| e.namespace && e.namespace.href.start_with?(ODF_NS) }
+end
+
+failures = 0
+check = lambda { |cond, msg| puts(cond ? "PASS: #{msg}" : "FAIL: #{msg}"); failures += 1 unless cond }
+
+samples = {
+  "anchor"      => %(<p>see <a href="http://x">the link</a> here</p>),
+  "b and i"     => "<p><b>bold</b> and <i>italic</i></p>",
+  "span class"  => %(<p><span class="hl">highlighted</span> text</p>),
+  "div wrapper" => "<div><p>wrapped</p></div>",
+  "entities"    => "<p>caf&eacute; &mdash; 50&nbsp;cents &amp; more</p>",
+  "list w/ a"   => %(<ul><li>plain</li><li><a href="x">linked</a> item</li></ul>),
+}
+
+samples.each do |name, html|
+  out = render(html)
+  check.(only_odf_elements?(out), "no foreign elements for: #{name}")
+  check.(!out.match?(/<(a|b|i|span|div)[ >\/]/), "no raw HTML tag leaks for: #{name}")
+end
+
+# <b>/<i> are honored as bold/italic (not just stripped)
+out = render("<p><b>x</b> <i>y</i></p>")
+spans = Nokogiri::XML(out).xpath("//text:span")
+styles = spans.map { |s| s["text:style-name"] }.sort
+check.(styles == %w[bold italic], "<b>->bold and <i>->italic spans")
+
+# anchor text is preserved even though the tag is dropped
+out = render(%(<p>go <a href="http://x">somewhere</a></p>))
+check.(Nokogiri::XML(out).at_xpath("//text:p").text.include?("somewhere"), "anchor text preserved")
+
+# &nbsp; becomes a real character, not a literal entity
+out = render("<p>a&nbsp;b</p>")
+check.(!out.include?("&nbsp;") && Nokogiri::XML(out).at_xpath("//text:p").text.include?("\u00A0"),
+       "&nbsp; decoded to a non-breaking space character")
+
+abort("\n#{failures} failure(s)") unless failures.zero?
+puts "\nOK (#{failures} failures)"

--- a/test/html_lists_test.rb
+++ b/test/html_lists_test.rb
@@ -1,0 +1,75 @@
+require "./lib/odf-report"
+require "tmpdir"
+
+NS = %(xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" ) +
+     %(xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0")
+
+def render(html)
+  Dir.mktmpdir do |dir|
+    src = File.join(dir, "tpl.odt")
+    Zip::OutputStream.open(src) do |z|
+      z.put_next_entry("mimetype"); z.write("application/vnd.oasis.opendocument.text")
+      z.put_next_entry("content.xml")
+      z.write(%(<?xml version="1.0"?><office:document-content #{NS}>) +
+              %(<office:body><office:text><text:p>[BODY]</text:p></office:text></office:body></office:document-content>))
+      z.put_next_entry("META-INF/manifest.xml")
+      z.write(%(<?xml version="1.0"?><manifest:manifest ) +
+              %(xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0">) +
+              %(<manifest:file-entry manifest:full-path="/" ) +
+              %(manifest:media-type="application/vnd.oasis.opendocument.text"/></manifest:manifest>))
+    end
+    out = File.join(dir, "out.odt")
+    ODFReport::Report.new(src) { |r| r.add_text(:body, html) }.generate(out)
+    Zip::File.open(out) { |z| return z.read("content.xml") }
+  end
+end
+
+def doc_of(content)
+  Nokogiri::XML(content)
+end
+
+failures = 0
+check = lambda { |cond, msg| puts(cond ? "PASS: #{msg}" : "FAIL: #{msg}"); failures += 1 unless cond }
+
+# flat unordered list
+out = render("<ul><li>first</li><li>second</li></ul>")
+d = doc_of(out)
+check.(d.errors.empty?, "output is well-formed XML")
+check.(d.xpath("//text:list").size == 1, "one text:list created")
+check.(d.xpath("//text:list/text:list-item").size == 2, "two list items")
+check.(d.xpath("//text:list/text:list-item/text:p").map(&:text) == %w[first second],
+       "items carry their text in text:p")
+check.(!out.include?("<li>") && !out.include?("<ul>"), "no raw HTML list tags remain")
+
+# inline formatting inside an item
+out = render("<ul><li>plain <strong>bold</strong> end</li></ul>")
+d = doc_of(out)
+span = d.at_xpath("//text:list-item//text:span")
+check.(span && span["text:style-name"] == "bold" && span.text == "bold",
+       "inline <strong> inside <li> becomes bold text:span")
+
+# nested list
+out = render("<ul><li>parent<ul><li>child a</li><li>child b</li></ul></li></ul>")
+d = doc_of(out)
+outer_item = d.at_xpath("//text:list/text:list-item")
+check.(outer_item.xpath("./text:list").size == 1, "nested text:list lives inside the parent list-item")
+check.(d.xpath("//text:list//text:list//text:list-item").size == 2, "nested list has its two items")
+
+# ordered list also produces a text:list
+out = render("<ol><li>one</li><li>two</li></ol>")
+check.(doc_of(out).xpath("//text:list/text:list-item").size == 2, "<ol> also yields a text:list")
+
+# ordering: paragraph, list, paragraph preserved
+out = render("<p>intro</p><ul><li>x</li></ul><p>after</p>")
+body = doc_of(out).at_xpath("//office:text")
+names = body.children.map(&:name).reject { |n| n.strip.empty? rescue false }
+check.(names == %w[p list p], "block order preserved: p, list, p (got #{names.inspect})")
+
+# regression: a plain paragraph with inline formatting still works
+out = render("<p>hello <strong>there</strong></p>")
+d = doc_of(out)
+check.(d.xpath("//text:list").empty? && d.at_xpath("//text:p/text:span")&.text == "there",
+       "plain paragraph + inline formatting still works (no list)")
+
+abort("\n#{failures} failure(s)") unless failures.zero?
+puts "\nOK (#{failures} failures)"


### PR DESCRIPTION
**Support HTML lists in add_text; fix invalid content.xml from HTML input**

Converts `<ul>/<ol>/<li>` (including nested) to ODF text:list, and fixes a bug where foreign tags (`<a>, <b>, <span>`) and HTML entities (`&nbsp;`) were passed through verbatim, producing invalid ODF that LibreOffice rejects with a "Format error".

The HTML-to-ODF conversion now walks nodes instead of regex: known tags map to ODF spans/line-breaks, any other tag is unwrapped (text kept), and text is taken decoded so no undefined entity reaches content.xml.

Includes tests for list structure and inline safety (asserting only ODF elements end up under office:text).